### PR TITLE
fix: restore namespaced OpenAPI generation and docs serving

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -37,6 +37,4 @@ plugins:
     out: dist/openapi
     opt:
       - logtostderr=true
-      - allow_merge=true
-      - merge_file_name=api
     include_imports: true

--- a/scripts/convert-swagger-to-openapi.sh
+++ b/scripts/convert-swagger-to-openapi.sh
@@ -5,7 +5,7 @@ set -e
 echo "Converting Swagger 2.0 to OpenAPI 3.0..."
 
 # Convert all swagger files using npx (uses locally installed version)
-for swagger_file in dist/openapi/*.swagger.json; do
+for swagger_file in $(find dist/openapi -name "*.swagger.json" -type f); do
     if [ -f "$swagger_file" ]; then
         openapi_file="${swagger_file%.swagger.json}.openapi.json"
         echo "Converting $(basename "$swagger_file") -> $(basename "$openapi_file")..."
@@ -18,7 +18,7 @@ done
 
 # Add server configurations to the OpenAPI specs
 echo "Adding server configurations..."
-for openapi_file in dist/openapi/*.openapi.json; do
+for openapi_file in $(find dist/openapi -name "*.openapi.json" -type f); do
     if [ -f "$openapi_file" ]; then
         echo "Adding servers to $(basename "$openapi_file")..."
         # Use jq to add servers array after the info section

--- a/scripts/serve-docs.sh
+++ b/scripts/serve-docs.sh
@@ -11,9 +11,11 @@ fi
 echo "Setting up Swagger UI..."
 mkdir -p dist/docs
 cp templates/swagger-ui.html dist/docs/index.html
+# Copy OpenAPI files to be accessible (match GitHub Pages structure)
+cp -r dist/openapi dist/docs/
 
 # Serve the docs
 echo "🚀 Serving OpenAPI docs at http://localhost:8080"
 echo "📖 View interactive API documentation with curl examples"
 echo "💡 Uses OpenAPI 3.0 format with native server dropdown"
-cd dist && python3 -m http.server 8080
+cd dist/docs && python3 -m http.server 8080

--- a/scripts/validate-openapi.py
+++ b/scripts/validate-openapi.py
@@ -10,8 +10,8 @@ def validate_openapi_files():
     """Validate all OpenAPI 3.0 JSON files."""
     print("📋 Validating OpenAPI 3.0 files...")
     
-    pattern = "dist/openapi/*.openapi.json"
-    openapi_files = glob.glob(pattern)
+    pattern = "dist/openapi/**/*.openapi.json"
+    openapi_files = glob.glob(pattern, recursive=True)
     
     if not openapi_files:
         print(f"  ❌ No OpenAPI files found matching: {pattern}")

--- a/scripts/validate-swagger.py
+++ b/scripts/validate-swagger.py
@@ -10,8 +10,8 @@ def validate_swagger_files():
     """Validate all Swagger 2.0 JSON files."""
     print("📋 Validating Swagger 2.0 files...")
     
-    pattern = "dist/openapi/*.swagger.json"
-    swagger_files = glob.glob(pattern)
+    pattern = "dist/openapi/**/*.swagger.json"
+    swagger_files = glob.glob(pattern, recursive=True)
     
     if not swagger_files:
         print(f"  ❌ No Swagger files found matching: {pattern}")


### PR DESCRIPTION
## Summary

Fixes `task docs` failure by restoring proper namespaced OpenAPI generation for the monorepo architecture.

## Problem

The OpenAPI generation was configured with merged output (`allow_merge=true`, `merge_file_name=api`), creating a single `api.openapi.json` file. However, the docs serving script expected namespaced files at `dist/openapi/cyberstorm/attestor/v1/services.openapi.json`.

## Solution

### OpenAPI Generation (`buf.gen.yaml`)
- ✅ **Removed merged output**: Disabled `allow_merge=true` and `merge_file_name=api` 
- ✅ **Restored namespacing**: Now generates proper module-specific paths
- ✅ **Future-ready**: Supports multiple services as the monorepo grows

### Conversion Script (`convert-swagger-to-openapi.sh`)
- ✅ **Fixed file discovery**: Changed from `dist/openapi/*.swagger.json` to `find` for nested files
- ✅ **Handles all modules**: Converts swagger files in subdirectories
- ✅ **Preserves structure**: Maintains the namespaced directory layout

### Generated Structure
```
dist/openapi/
├── cyberstorm/
│   ├── attestor/v1/
│   │   ├── services.openapi.json ✅
│   │   ├── services.swagger.json
│   │   └── messages.openapi.json
│   └── crypto/v1/
│       └── crypto.openapi.json
└── [other dependencies...]
```

## Testing

- ✅ **Generation**: `task generate:openapi` creates namespaced files
- ✅ **Conversion**: All swagger files converted to OpenAPI 3.0  
- ✅ **Docs serving**: `task docs` starts successfully at http://localhost:8080
- ✅ **Structure**: Files generated at expected paths for monorepo

## Benefits

- **Proper namespacing**: Each module gets its own OpenAPI documentation
- **Future-proof**: Ready for additional services and modules
- **Clean separation**: Services documentation remains organized by module
- **Standards compliance**: Follows monorepo best practices

This maintains the correct file structure for serving module-specific API documentation.