### PR TITLE
feat: add chain context to SchemaDeployment message for v1.0.4

### DIFF
--- a/cyberstorm/attestor/v1/buf.lock
+++ b/cyberstorm/attestor/v1/buf.lock
@@ -2,8 +2,8 @@
 version: v2
 deps:
   - name: buf.build/bufbuild/protovalidate
-    commit: 6c6e0d3c608e4549802254a2eee81bc8
-    digest: b5:a7ca081f38656fc0f5aaa685cc111d3342876723851b47ca6b80cbb810cbb2380f8c444115c495ada58fa1f85eff44e68dc54a445761c195acdb5e8d9af675b6
+    commit: 52f32327d4b045a79293a6ad4e7e1236
+    digest: b5:cbabc98d4b7b7b0447c9b15f68eeb8a7a44ef8516cb386ac5f66e7fd4062cd6723ed3f452ad8c384b851f79e33d26e7f8a94e2b807282b3def1cd966c7eace97
   - name: buf.build/cyberstorm/eas
     commit: b4a28c7fa8cc432b9d752f96149a6c52
     digest: b5:ead7192af1236210abe4fe2bb642b504eaf94ea36350ed1a6bdaa39ea69e9abe2fb21d46fca2aabd19b598c10a51a73ebd8a7fe600742bb6be500935a3ed6279

--- a/cyberstorm/attestor/v1/cyberstorm/attestor/v1/services.proto
+++ b/cyberstorm/attestor/v1/cyberstorm/attestor/v1/services.proto
@@ -222,6 +222,8 @@ message SchemaDefinition {
 message SchemaDeployment {
   string contract_name = 1;
   string contract_address = 2;    // Schema UID
+  uint64 chain_id = 3;           // EVM chain ID (1 = Ethereum mainnet, 137 = Polygon, etc.)
+  string chain_name = 4;         // Human-readable chain name
 }
 
 message GetSchemaRequest {

--- a/cyberstorm/crypto/v1/buf.lock
+++ b/cyberstorm/crypto/v1/buf.lock
@@ -2,5 +2,5 @@
 version: v2
 deps:
   - name: buf.build/bufbuild/protovalidate
-    commit: 6c6e0d3c608e4549802254a2eee81bc8
-    digest: b5:a7ca081f38656fc0f5aaa685cc111d3342876723851b47ca6b80cbb810cbb2380f8c444115c495ada58fa1f85eff44e68dc54a445761c195acdb5e8d9af675b6
+    commit: 52f32327d4b045a79293a6ad4e7e1236
+    digest: b5:cbabc98d4b7b7b0447c9b15f68eeb8a7a44ef8516cb386ac5f66e7fd4062cd6723ed3f452ad8c384b851f79e33d26e7f8a94e2b807282b3def1cd966c7eace97

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cyberstorm/schemas",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cyberstorm/schemas",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "google-protobuf": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyberstorm/schemas",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Protocol Buffer schemas and generated clients for Cyberstorm services",
   "main": "src/index.js",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cyberstorm-schemas"
-version = "1.0.3"
+version = "1.0.4"
 description = "Protocol Buffer schemas and generated clients for Cyberstorm services"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Adds essential chain context fields to the  message to enable proper multi-chain support.

## Changes

- **Add  field (uint64)**: EVM chain ID for programmatic identification (e.g., 1 = Ethereum mainnet, 137 = Polygon)
- **Add  field (string)**: Human-readable chain name for display purposes

## Problem Solved

Previously, message processors receiving  information had no way to determine:
- Which blockchain the deployment was on
- How to route deployments to the correct chain
- How to validate deployments against expected chain context

## Impact

- ✅ Enables proper multi-chain deployment tracking
- ✅ Allows message processors to route deployments correctly  
- ✅ Provides both programmatic (chain_id) and human-readable (chain_name) chain identification
- ✅ Maintains backward compatibility (new fields are optional)

## Version

This change corresponds to the **v1.0.4** release.

## Proto Changes



## Test Plan

- [x] Proto file validates successfully
- [x] Generated clients compile without errors
- [x] Backward compatibility maintained
- [x] Documentation reflects new fields